### PR TITLE
前後台API新增與調整

### DIFF
--- a/routes/admin.ts
+++ b/routes/admin.ts
@@ -31,9 +31,9 @@ router.get('/projects', authMiddleware, checkAdminAuth, async (req, res) => {
     }
     * #swagger.parameters['sortDesc'] = {
       in: 'query',
-      description: '提案新舊排序，預設為 false (新->舊)',
+      description: '提案新舊排序，預設為 true，也可以用 1、-1 參數<br>true、1 為新到舊排序<br>false、-1 為舊到新排序',
       type: 'boolean',
-      default: 'false'
+      default: 'true'
     }
     * #swagger.parameters['status'] = {
       in: 'query',
@@ -52,15 +52,37 @@ router.get('/projects', authMiddleware, checkAdminAuth, async (req, res) => {
     schema: {
         "status": "success",
         "message": "取得提案列表",
-        "results": {
-            "projects": "...data"
-        },
+        "results": [{
+          "_id": "6652d5104fd5c3080e3e5795",
+          "introduce": "專業金援團隊，弱勢族群救星，幫助許多需要協助的家庭。",
+          "teamName": "弱勢救星",
+          "email": "nomail@mail.com",
+          "phone": "0938938438",
+          "title": "測試送審",
+          "categoryKey": 2,
+          "targetMoney": 30000,
+          "startDate": 1720713600,
+          "endDate": 1721577600,
+          "describe": "一場無情的大火吞噬了整個社區，請幫助無家可歸的民眾。",
+          "coverUrl": "https://fakeimg.pl/300/",
+          "content": "<p>test</p>",
+          "videoUrl": "",
+          "relatedUrl": "",
+          "feedbackItem": "限量精美小熊維尼",
+          "feedbackUrl": "https://fakeimg.pl/300/",
+          "feedbackMoney": 100,
+          "feedbackDate": 1721577600,
+          "createTime": 1716704528,
+          "updateTime": 1716704528,
+          "nickName": "",
+          "status": 0
+        }],
         "pagination": {
             "pageNo": 1,
             "pageSize": 10,
-            "totalPage": 3,
-            "count": 25,
-            "sortDesc": false,
+            "totalPage": 1,
+            "count": 1,
+            "sortDesc": true,
             "status": 0,
             "search": "關鍵字搜尋"
           }
@@ -74,7 +96,7 @@ router.get('/projects', authMiddleware, checkAdminAuth, async (req, res) => {
     // 請求參數檢查
     const errorMsg = []
     const { pageNo = 1, pageSize = 10, sortDesc = 'false', status = 0, search = '' } = req.query
-    let sort: any = '1'
+    let sort = 1
     // 當前頁數
     if (!Number(pageNo) || Number(pageNo) < 1) {
       errorMsg.push('當前頁數錯誤')
@@ -86,10 +108,10 @@ router.get('/projects', authMiddleware, checkAdminAuth, async (req, res) => {
     }
 
     // 提案新舊排序
-    if (!['true', 'false'].includes(sortDesc.toString())) {
+    if (![1, -1, 'true', 'false'].includes(sortDesc as any)) {
       errorMsg.push('提案新舊排序錯誤')
     } else {
-      sort = sortDesc === 'true' ? 1 : -1
+      sort = [-1, 'false'].includes(sortDesc as any) ? -1 : 1
     }
 
     // 提案狀態 （N = 0:[預設]送審 1:核准 -1:否准 2:已結束 3:全部）
@@ -221,7 +243,7 @@ router.get('/projects', authMiddleware, checkAdminAuth, async (req, res) => {
             reviewLog: 0
           }
         },
-        { $sort: { startDate: sort } },
+        { $sort: { startDate: sort as any } },
         { $skip: (Number(safePageNo) - 1) * Number(pageSize) },
         { $limit: Number(pageSize) }
       ])
@@ -255,7 +277,7 @@ router.get('/projects', authMiddleware, checkAdminAuth, async (req, res) => {
 })
 
 // 管理端 取得提案內容 GET /admin/projects/{projectId}
-router.get('/projects/:projectId', authMiddleware, checkAdminAuth, async (req, res) => {
+router.get('/projects/:projectId', authMiddleware, checkAdminAuth, async (req, res, next) => {
   /**
    * #swagger.tags = ['Admin - 管理端']
    * #swagger.description = '取得提案內容'
@@ -268,7 +290,37 @@ router.get('/projects/:projectId', authMiddleware, checkAdminAuth, async (req, r
       "status": "success",
       "message": "取得提案資料成功",
       "results": {
-          "projects": "...data"
+        "_id": "66401d4618d9a03d581946fc",
+        "introduce": "大家好，我們是廣福國小六年級資優班的學生，我們希望能透過自己的能力及創意籌得資優班畢旅的資金。 老師教導我們要成為懂得幫助他人的人，所以在每次籌辦活動後我們都會做一件幫助他人的事情！",
+        "teamName": "愛在西元前",
+        "email": "elsa@gamil.com",
+        "phone": "0955123123",
+        "title": "六優畢旅自籌計畫—【一趟讓國小資優生實踐自主公益計畫的畢業旅行】",
+        "categoryKey": 1,
+        "targetMoney": 100000,
+        "startDate": 1714534369,
+        "endDate": 1715439897,
+        "describe": "一輩子只有一次的國小資優生畢業旅行",
+        "coverUrl": "https://picsum.photos/id/65/200/300",
+        "content": "<p>在資優班情意課課程時，老師剛好上到我們如何「同理他人」，我們想到普通班會去一次畢旅，爸爸媽媽就要負擔4張小朋友左右的費用，如果資優班的畢旅可以靠我們自己的能力籌得經費，那不但可以替爸爸媽媽省錢，也能在過程中學習如何籌畫好一個計劃。<br><br>於是計畫就這麼開始了！<br><br>在大家有共識決定自籌畢旅，在腦力激盪階段，我們把從四年級到現在在資優班學習到的概念拿來推敲一番，四年級情意課學習「事情的一體兩面」、五年級特色課程從「能源議題」出發，結合SDGs聯合國永續發展目標我們學習到能源從哪裡來、省電的重要、什麼是碳排放以及永續的重要性，並執行了「檢視自己一週食衣住行育樂碳排放量」的活動，從中我們學會了關注生活及環保觀念。</p>",
+        "videoUrl": "https://youtu.be/Iy69ifIf7jc?si=rX3_ZAdEhvgsUbu5",
+        "relatedUrl": "www.google.com",
+        "feedbackItem": "學生書寫的電子感謝函",
+        "feedbackUrl": "",
+        "feedbackMoney": 5000,
+        "feedbackDate": 1718118294,
+        "reviewLog": [
+          {
+            "_id": "663e4c59d8b15d4452a72a63",
+            "content": "待審核",
+            "status": 0,
+            "timestamp": 1715358809
+          }
+        ],
+        "state": {
+          "state": 2,
+          "content": "已結束"
+        }
       }
     }
   }
@@ -283,6 +335,18 @@ router.get('/projects/:projectId', authMiddleware, checkAdminAuth, async (req, r
         message: '錯誤的提案編號格式'
       })
     }
+
+    // 先檢查提案是否有審核紀錄，若沒有任何審核與送審紀錄則先補建一筆
+    const countProjectCheck = await CheckModel.countDocuments({ projectId })
+    if (!countProjectCheck) {
+      await createCheck({
+        projectId: projectId as any,
+        content: '',
+        status: 0,
+        next
+      })
+    }
+
     const projectData = await ProjectModel.aggregate([
       {
         $match: { _id: new Types.ObjectId(projectId) }

--- a/routes/member.ts
+++ b/routes/member.ts
@@ -362,10 +362,10 @@ router.get('/projects', authMiddleware, async (req, res) => {
       ])
 
       const eachStateCount = {
-        ongoing:allProjects.filter((obj)=> obj.state==1 && obj.endDate >= Date.now()/1000).length,
-        rejected:allProjects.filter((obj)=> obj.state==-1).length,
-        pending:allProjects.filter((obj)=> obj.state==0).length,
-        ended:allProjects.filter((obj)=> obj.state==1 && obj.endDate < Date.now()/1000).length,
+        ongoing: allProjects.filter((obj) => obj.state == 1 && obj.endDate >= Date.now() / 1000).length,
+        rejected: allProjects.filter((obj) => obj.state == -1).length,
+        pending: allProjects.filter((obj) => obj.state == 0).length,
+        ended: allProjects.filter((obj) => obj.state == 1 && obj.endDate < Date.now() / 1000).length
         // total: allProjects.length,
         // allProjects,
         // now: Date.now()/1000
@@ -389,7 +389,7 @@ router.get('/projects', authMiddleware, async (req, res) => {
       const totalPage = Math.ceil(totalProjects / Number(pageSize))
       const safePageNo = Number(pageNo) > totalPage ? 1 : pageNo
 
-      // 
+      //
       // 提案狀態查詢邏輯
       let stateFilter = {}
       switch (Number(state)) {
@@ -473,7 +473,7 @@ router.get('/projects', authMiddleware, async (req, res) => {
             updateTime: 0
           }
         },
-        
+
         { $match: stateFilter },
         { $skip: (Number(safePageNo) - 1) * Number(pageSize) },
         { $limit: Number(pageSize) },
@@ -508,16 +508,16 @@ router.get('/projects', authMiddleware, async (req, res) => {
         },
         {
           $addFields: {
-            achievedMoney: { $sum: "$sponsorLog.money" },
-            sponsorCount:{ $size: '$sponsorLog'}
-            }
+            achievedMoney: { $sum: '$sponsorLog.money' },
+            sponsorCount: { $size: '$sponsorLog' }
+          }
         },
         {
           $project: {
             sponsorLog: 0,
             _id: 0,
-            state:0,
-            latestCheck: 0,
+            state: 0,
+            latestCheck: 0
           }
         }
       ])
@@ -532,7 +532,7 @@ router.get('/projects', authMiddleware, async (req, res) => {
         pagination: {
           pageNo: Number(safePageNo),
           pageSize: Number(pageSize),
-          count: totalProjects,
+          count: totalProjects
         }
       })
     } else {
@@ -723,18 +723,37 @@ router.get('/collection', authMiddleware, async (req, res) => {
     schema: {
       "status": "success",
       "message": "取得追蹤列表成功",
-      "results": {
-          "projects": "...data"
-        },
+      "results": [{
+        "_id": "66401d4618d9a03d581946fd",
+        "userId": "663a54b8c9225d0f16b55020",
+        "introduce": "災害應變知識應該是公開的，邀請你一起降低公民參與門檻，製作「免費線上手冊」，讓所有人都能隨時取得、自學練習，隨時做好災害應變準備，保護自己與身邊的人。 壯闊台灣聯盟是獨立的非營利組織，工作圍繞著提升國家韌性、社會安全、民主治理與整體競爭力。Take action today - 成為彼此的後盾！",
+        "teamName": "愛在西元前",
+        "email": "elsa@gamil.com",
+        "phone": "0955123123",
+        "title": "壯闊台灣開源計畫｜公開災害應變知識，一起自主學習！",
+        "categoryKey": 1,
+        "targetMoney": 500000,
+        "startDate": 1715439897,
+        "endDate": 1718118294,
+        "describe": "公開災害應變知識，一起自主學習！",
+        "coverUrl": "https://picsum.photos/id/61/200/300",
+        "content": "<p>最近一次地震發生時，你還記得你的反應是什麼嗎？無論自己是當事人或只是旁觀者，上次遇到事故，你第一時間的反應又是什麼？面對無法預期的突發狀況，唯有最好準備，才能保護身邊的人。<br><br>台灣地理與地緣政治環境特殊，我們面臨各種天災與人為的風險，事情發生當下沒有思考的時間，#BePrepared !<br><br>邀請你，支持「壯闊台灣開源計畫｜公開災害應變知識，一起自主學習！」，提供免費線上手冊、讓學習與取用沒有侷限，讓更多人有能力在關鍵時刻伸出援手。</p>",
+        "videoUrl": "https://youtu.be/Iy69ifIf7jc?si=rX3_ZAdEhvgsUbu5",
+        "relatedUrl": "www.google.com",
+        "feedbackItem": "止血帶包",
+        "feedbackUrl": "",
+        "feedbackMoney": 10000,
+        "feedbackDate": 1718118294,
+        "trackingStatus": true
+      }],
       "pagination": {
-          "pageNo": 1,
-          "pageSize": 10,
-          "totalPage": 3,
-          "count": 25,
-          "sortDesc": false,
-          "status": 0,
-          "search": "關鍵字搜尋"
-        }
+        "pageNo": 1,
+        "pageSize": 10,
+        "hasNext": false,
+        "hasPre": false,
+        "totalPage": 1,
+        "count": 1
+      }
     }
   }
   *
@@ -834,8 +853,7 @@ router.get(
         schema: {
           "status": "success",
           "message": "取得未讀通知成功",
-          "results": [
-            {
+          "results": [{
               "id": "664cc9c63171e09ae23b2c9e",
               "content": "「測試修改送審」審核已過審",
               "isRead": true,
@@ -845,8 +863,7 @@ router.get(
                   "title": "測試修改送審",
                   "coverUrl": "https://fakeimg.pl/300/"
               }
-            }
-          ],
+            }],
           "pagination": {
             "count": 2,
             "pageNo": 1,
@@ -929,6 +946,298 @@ router.get(
     })
   })
 )
+// 用戶端 贊助紀錄 GET /member/support
+router.get('/support', authMiddleware, async (req, res) => {
+  /**
+   * #swagger.tags = ['Member - 會員中心']
+   * #swagger.description = '取得贊助紀錄'
+   * #swagger.security = [{
+      token: []
+    }]
+    * #swagger.parameters['pageNo'] = {
+      in: 'query',
+      description: '當前頁數',
+      type: 'number',
+      default: '1'
+    }
+    * #swagger.parameters['pageSize'] = {
+      in: 'query',
+      description: '單頁筆數',
+      type: 'number',
+      default: '10'
+    }
+  * #swagger.responses[200] = {
+    description: '取得贊助紀錄成功',
+    schema: {
+      "status": "success",
+      "message": "取得贊助紀錄成功",
+      "results": [{
+        "_id": "665876fe0200b4355521bd0c",
+        "money": 12000,
+        "isNeedFeedback": true,
+        "receiver": "Hank林",
+        "receiverPhone": "0987987987",
+        "address": "台北市大馬路123號",
+        "createTime": 1716181992,
+        "updateTime": 1716181992,
+        "email": "hank@gmail.com",
+        "categoryKey": 1,
+        "feedBackDate": 1718118294,
+        "project": {
+          "title": "壯闊台灣開源計畫｜公開災害應變知識，一起自主學習！",
+          "feedbackItem": "止血帶包",
+          "categoryKey": 1
+        }
+      }],
+      "pagination": {
+        "pageNo": 1,
+        "pageSize": 10,
+        "hasNext": false,
+        "hasPre": false,
+        "totalPage": 1,
+        "count": 1
+      }
+    }
+  }
+  *
+  */
+
+  try {
+    // 請求參數檢查
+    const errorMsg = []
+    const { id } = (req as any).user
+    const { pageNo = 1, pageSize = 10 } = req.query
+
+    // 當前頁數
+    if (!Number(pageNo) || Number(pageNo) < 1) {
+      errorMsg.push('當前頁數錯誤')
+    }
+
+    // 單頁筆數
+    if (!Number(pageSize) || Number(pageSize) < 1) {
+      errorMsg.push('單頁筆數錯誤')
+    }
+
+    if (errorMsg.length === 0) {
+      const sponsorFilter = { userId: new Types.ObjectId(id) }
+      const totalSponsors = await Sponsor.countDocuments(sponsorFilter)
+      const totalPage = Math.ceil(totalSponsors / Number(pageSize))
+      const safePageNo = Number(pageNo) > totalPage ? 1 : pageNo
+
+      const sponsors = await Sponsor.aggregate([
+        { $match: sponsorFilter },
+        {
+          $lookup: {
+            from: 'users',
+            localField: 'userId',
+            foreignField: '_id',
+            as: 'userId'
+          }
+        },
+        {
+          $lookup: {
+            from: 'projects',
+            localField: 'projectId',
+            foreignField: '_id',
+            as: 'projectId'
+          }
+        },
+        { $unwind: '$projectId' },
+        {
+          $addFields: {
+            email: '$userId.email',
+            categoryKey: '$projectId.categoryKey',
+            feedBackDate: '$projectId.feedbackDate',
+            project: {
+              title: '$projectId.title',
+              feedbackItem: '$projectId.feedbackItem',
+              categoryKey: '$projectId.categoryKey'
+            }
+          }
+        },
+        { $unwind: '$email' },
+        { $unwind: '$feedBackDate' },
+        {
+          $project: {
+            userId: 0,
+            userName: 0,
+            projectId: 0,
+            phone: 0
+          }
+        },
+        { $skip: (Number(safePageNo) - 1) * Number(pageSize) },
+        { $limit: Number(pageSize) }
+      ])
+
+      return res.status(200).json({
+        status: 'success',
+        message: totalSponsors ? '取得贊助紀錄成功' : '還沒有贊助的提案',
+        results: sponsors,
+        pagination: {
+          pageNo: Number(safePageNo),
+          pageSize: Number(pageSize),
+          hasNext: Number(safePageNo) < totalPage,
+          hasPre: Number(safePageNo) > 1,
+          totalPage,
+          count: totalSponsors
+        }
+      })
+    } else {
+      return res.status(400).json({
+        status: 'error',
+        message: `發生錯誤 ${errorMsg.join()}`
+      })
+    }
+  } catch (error) {
+    return res.status(500).json({
+      status: 'error',
+      message: '伺服器錯誤' + error
+    })
+  }
+})
+
+// 用戶端 贊助名單 GET /member/support/{projectId}
+router.get('/support/:projectId', authMiddleware, async (req, res) => {
+  /**
+   * #swagger.tags = ['Member - 會員中心']
+   * #swagger.description = '取得贊助名單'
+   * #swagger.security = [{
+      token: []
+    }]
+    * #swagger.parameters['pageNo'] = {
+      in: 'query',
+      description: '當前頁數',
+      type: 'number',
+      default: '1'
+    }
+    * #swagger.parameters['pageSize'] = {
+      in: 'query',
+      description: '單頁筆數',
+      type: 'number',
+      default: '10'
+    }
+  * #swagger.responses[200] = {
+    description: '取得贊助名單成功',
+    schema: {
+      "status": "success",
+      "message":"取得贊助名單成功",
+      "results": [{
+        "_id": "665876fe0200b4355521bd0c",
+        "money": 12000,
+        "isNeedFeedback": true,
+        "receiver": "Hank林",
+        "receiverPhone": "0987987987",
+        "address": "台北市大馬路123號",
+        "createTime": 1716181992,
+        "updateTime": 1716181992,
+        "email": "hank@gmail.com",
+        "feedbackMoney": 10000
+      }],
+      "pagination": {
+          "pageNo": 1,
+          "pageSize": 10,
+          "hasNext": false,
+          "hasPre": false,
+          "totalPage": 1,
+          "count": 1
+        }
+    }
+  }
+  *
+  */
+
+  try {
+    // 請求參數檢查
+    const errorMsg = []
+    const { pageNo = 1, pageSize = 10 } = req.query
+    const projectId = req.params.projectId || 'empty'
+    if (!Types.ObjectId.isValid(String(projectId))) {
+      return res.status(400).json({
+        status: 'error',
+        message: '錯誤的提案編號格式'
+      })
+    }
+
+    // 當前頁數
+    if (!Number(pageNo) || Number(pageNo) < 1) {
+      errorMsg.push('當前頁數錯誤')
+    }
+
+    // 單頁筆數
+    if (!Number(pageSize) || Number(pageSize) < 1) {
+      errorMsg.push('單頁筆數錯誤')
+    }
+
+    if (errorMsg.length === 0) {
+      const sponsorFilter = { projectId: new Types.ObjectId(projectId) }
+      const totalSponsors = await Sponsor.countDocuments(sponsorFilter)
+      const totalPage = Math.ceil(totalSponsors / Number(pageSize))
+      const safePageNo = Number(pageNo) > totalPage ? 1 : pageNo
+
+      const sponsor = await Sponsor.aggregate([
+        { $match: sponsorFilter },
+        {
+          $lookup: {
+            from: 'users',
+            localField: 'userId',
+            foreignField: '_id',
+            as: 'userId'
+          }
+        },
+        {
+          $lookup: {
+            from: 'projects',
+            localField: 'projectId',
+            foreignField: '_id',
+            as: 'projectId'
+          }
+        },
+        { $unwind: '$projectId' },
+        {
+          $addFields: {
+            email: '$userId.email',
+            feedbackMoney: '$projectId.feedbackMoney'
+          }
+        },
+        { $unwind: '$email' },
+        {
+          $project: {
+            userId: 0,
+            userName: 0,
+            projectId: 0,
+            phone: 0
+          }
+        },
+        { $skip: (Number(safePageNo) - 1) * Number(pageSize) },
+        { $limit: Number(pageSize) }
+      ])
+
+      return res.status(200).json({
+        status: 'success',
+        message: totalSponsors ? '取得贊助名單成功' : '還沒有贊助的紀錄',
+        results: sponsor,
+        pagination: {
+          pageNo: Number(safePageNo),
+          pageSize: Number(pageSize),
+          hasNext: Number(safePageNo) < totalPage,
+          hasPre: Number(safePageNo) > 1,
+          totalPage,
+          count: totalSponsors
+        }
+      })
+    } else {
+      return res.status(400).json({
+        status: 'error',
+        message: `發生錯誤 ${errorMsg.join()}`
+      })
+    }
+  } catch (error) {
+    return res.status(500).json({
+      status: 'error',
+      message: '伺服器錯誤' + error
+    })
+  }
+})
 
 // 取得未讀通知數量
 router.get(


### PR DESCRIPTION
### 前台
- 前台加入了會員贊助紀錄API、提案贊助列表API
### 後台
- 後台列表的排序功能參數，可以用ture/false或1/-1，並更新swagger說明
- 後台取得提案內容API加入了檢查審核紀錄，若沒任何送審與審核則會補建送審紀錄